### PR TITLE
move data directory during install, while preserving permissions #174

### DIFF
--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -32,25 +32,15 @@ directory node['postgresql']['config']['data_directory'] do
   owner 'postgres'
   group 'postgres'
   mode '0700'
+  notifies :run, 'ruby_block[moving data directory]', :immediately
 end
 
-ruby_block "creating initial data directory" do
+ruby_block "moving data directory" do
   block do
-    FileUtils.cp_r(Dir["/var/lib/postgresql/#{node['postgresql']['version']}/main/*"], node['postgresql']['config']['data_directory'])
+    FileUtils.cp_r(Dir["/var/lib/postgresql/#{node['postgresql']['version']}/main/*"], node['postgresql']['config']['data_directory'], :preserve => true)
   end
   only_if { Dir["#{node['postgresql']['config']['data_directory']}/*"].empty? }
-end
-
-execute "chown data dir to postgres" do
-  command "chown -R postgres:postgres #{node['postgresql']['config']['data_directory']}"
-  user "root"
-  action :run
-end
-
-execute "chmod data dir to postgres" do
-  command "chmod -R 700 #{node['postgresql']['config']['data_directory']}"
-  user "root"
-  action :run
+  action :nothing
 end
 
 service "postgresql" do


### PR DESCRIPTION
We should use the cp_r :preserve option so there is no need of the chown blocks anymore.
And trigger run action of the block by a notifier to ensure the move only occurs after the data directory was created.
